### PR TITLE
인터페이스 분리 (UserDao 내부에서 인터페이스 참조하도록 수정)

### DIFF
--- a/src/main/java/ConnectionMaker.java
+++ b/src/main/java/ConnectionMaker.java
@@ -1,0 +1,6 @@
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ConnectionMaker {
+    Connection makeConnection() throws ClassNotFoundException, SQLException;
+}

--- a/src/main/java/SimpleConnectionMaker.java
+++ b/src/main/java/SimpleConnectionMaker.java
@@ -2,10 +2,12 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-public class SimpleConnectionMaker {
-    public Connection makeNewConnection() throws ClassNotFoundException, SQLException {
+public class SimpleConnectionMaker implements ConnectionMaker {
+    @Override
+    public Connection makeConnection() throws ClassNotFoundException, SQLException {
         Class.forName("org.postgresql.Driver");
         return DriverManager.getConnection(
                 "jdbc:postgresql://localhost/toby-spring", "follower", "hello");
+
     }
 }

--- a/src/main/java/UserDao.java
+++ b/src/main/java/UserDao.java
@@ -1,18 +1,17 @@
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class UserDao {
-    private SimpleConnectionMaker simpleConnectionMaker;
+    private final ConnectionMaker connectionMaker;
 
     public UserDao() {
-        simpleConnectionMaker = new SimpleConnectionMaker();
+        connectionMaker = new SimpleConnectionMaker();
     }
 
     public void add(User user) throws ClassNotFoundException, SQLException {
-        final Connection c = simpleConnectionMaker.makeNewConnection();
+        final Connection c = connectionMaker.makeConnection();
         final PreparedStatement ps = c.prepareStatement(
                 "insert into users(id, name, password) values(?,?,?)");
         ps.setString(1, user.getId());
@@ -26,7 +25,7 @@ public class UserDao {
     }
 
     public User get(String id) throws ClassNotFoundException, SQLException {
-        final Connection c = simpleConnectionMaker.makeNewConnection();
+        final Connection c = connectionMaker.makeConnection();
         final PreparedStatement ps = c.prepareStatement(
                 "select * from users where id = ?");
         ps.setString(1, id);


### PR DESCRIPTION
### 요약
- DB 연결을 다르게 구현하는 고객사는 이제 인터페이스라는 규칙을 지키도록 가이드 할 수 있습니다. 
- 그리고 공급자인 UserDao 내부에서는 인터페이스를 참조하도록 하여, DB 연결에 대한 인터페이스에만 관심을 가지고 구체적인 구현에 독립적으로 코드를 작성할 수 있습니다. 
### 한계 
- 그러나 여전히 UserDao를 처음 생성할 때 어떤 구체클래스를 생성할지 알고 있어야 하고, 각 고객사에서는 UserDao를 수정해야만 DB 연결을 다르게 하는 클래스를 변경해 줄 수 있습니다. 